### PR TITLE
Fix forced line breaks in KFX text content

### DIFF
--- a/src/export/html_synth.rs
+++ b/src/export/html_synth.rs
@@ -173,7 +173,17 @@ fn walk_node<R: StyleResolver>(id: NodeId, ctx: &mut SynthesisContext<'_, R>) {
     // Handle leaf text nodes (Text role with text content, no children)
     if role == Role::Text && !node.text.is_empty() && node.first_child.is_none() {
         let text = ctx.ir.text(node.text);
-        ctx.out.push_str(&escape_xml(text));
+        // KFX uses \n in text content for forced line breaks — emit as <br/>
+        if text.contains('\n') {
+            for (i, segment) in text.split('\n').enumerate() {
+                if i > 0 {
+                    ctx.out.push_str("<br/>");
+                }
+                ctx.out.push_str(&escape_xml(segment));
+            }
+        } else {
+            ctx.out.push_str(&escape_xml(text));
+        }
         return;
     }
 
@@ -608,5 +618,50 @@ mod tests {
         assert!(result.body.contains("<h4>"));
         assert!(result.body.contains("<h5>"));
         assert!(result.body.contains("<h6>"));
+    }
+
+    #[test]
+    fn test_text_newlines_become_br() {
+        let mut chapter = Chapter::new();
+
+        let para = chapter.alloc_node(Node::new(Role::Paragraph));
+        chapter.append_child(NodeId::ROOT, para);
+
+        // Text with embedded newline (KFX forced line break)
+        let text_range = chapter.append_text("Interface Culture:\nHow New Technology");
+        let text_node = chapter.alloc_node(Node::text(text_range));
+        chapter.append_child(para, text_node);
+
+        let result = synthesize_html(&chapter, &HashMap::new());
+
+        assert!(
+            result
+                .body
+                .contains("Interface Culture:<br/>How New Technology"),
+            "Newlines in text content should become <br/> tags, got: {}",
+            result.body
+        );
+        // Should NOT contain a bare newline between the segments
+        assert!(
+            !result.body.contains("Culture:\nHow"),
+            "Raw newline should not appear in HTML output"
+        );
+    }
+
+    #[test]
+    fn test_text_without_newlines_unchanged() {
+        let mut chapter = Chapter::new();
+
+        let para = chapter.alloc_node(Node::new(Role::Paragraph));
+        chapter.append_child(NodeId::ROOT, para);
+
+        let text_range = chapter.append_text("Normal text without breaks");
+        let text_node = chapter.alloc_node(Node::text(text_range));
+        chapter.append_child(para, text_node);
+
+        let result = synthesize_html(&chapter, &HashMap::new());
+
+        assert!(result.body.contains("Normal text without breaks"));
+        assert!(!result.body.contains("<br/>"));
     }
 }

--- a/src/kfx/schema.rs
+++ b/src/kfx/schema.rs
@@ -480,6 +480,19 @@ impl KfxSchema {
             vec![],
         );
 
+        // Line break (<br/>)
+        // Note: KFX forced line breaks are primarily encoded as \n within text
+        // content (handled in html_synth.rs), but register the element type too
+        // in case some books use a discrete line_break element.
+        self.register_element(
+            KfxSymbol::LineBreak,
+            Strategy::Structure {
+                role: Role::Break,
+                kfx_type: KfxSymbol::LineBreak,
+            },
+            vec![],
+        );
+
         // BlockQuote - maps to type: text with yj.semantics.type: block_quote
         // KFX has no dedicated blockquote container. Instead it uses:
         // 1. type: text (standard text container)


### PR DESCRIPTION
Fixes #8

## Summary

KFX encodes forced line breaks as literal `\n` characters within text content strings (Ion string values in Content entities, symbol `$145`). The HTML synthesizer emitted these as insignificant whitespace, causing lines that should be visually separated to merge into a single line in EPUB output.

- Convert `\n` in text content to `<br/>` tags during HTML synthesis
- Register `KfxSymbol::LineBreak` (780) element type in the schema for books that use discrete `line_break` elements

**Files changed:** `src/export/html_synth.rs`, `src/kfx/schema.rs`

## Example

KFX text content: `"Interface Culture:\nHow New Technology"`

Before: `Interface Culture: How New Technology` (newline swallowed)
After: `Interface Culture:<br/>How New Technology` (visible line break)

## Format references

KFX is undocumented by Amazon; the format is reverse-engineered. Key references:

- **FriendsOfEpub KFX documentation** — [KindlePreviewer3.md](https://github.com/FriendsOfEpub/WillThatBeOverriden/blob/master/ReadingSystems/Kindle/KDF-KFX/KindlePreviewer3.md) describes KFX content structure: *"content types being based on HTML (container for nested div, text for div, p, h1, etc.)"*
- **FriendsOfEpub ionnames.csv** — [symbol table](https://raw.githubusercontent.com/FriendsOfEpub/WillThatBeOverriden/master/ReadingSystems/Kindle/KDF-KFX/ionnames.csv) maps `$145` = Content, `$146` = ContentList. The `line_break` symbol (`$780`) was added after this documentation was created.
- **Amazon Ion spec** — [strings documentation](https://amazon-ion.github.io/ion-docs/docs/stringclob.html) confirms Ion preserves literal `\n` (U+000A) within string values.

## Test plan

- [x] `test_text_newlines_become_br` — verifies `\n` → `<br/>` conversion
- [x] `test_text_without_newlines_unchanged` — verifies no false positives on normal text
- [x] Full test suite passes (496 existing + 2 new)