### PR TITLE
Quote multi-word and digit-prefixed font-family names in CSS

### DIFF
--- a/src/style/to_css.rs
+++ b/src/style/to_css.rs
@@ -73,7 +73,9 @@ impl ToCss for ComputedStyle {
 
         // Font properties
         if let Some(ref family) = self.font_family {
-            write!(buf, "font-family: {}; ", family).unwrap();
+            buf.push_str("font-family: ");
+            quote_font_family(buf, family);
+            buf.push_str("; ");
         }
         emit_if_changed!(self, default, buf, font_size, "font-size");
         emit_if_changed!(self, default, buf, font_weight, "font-weight");
@@ -237,5 +239,122 @@ impl ToCss for ComputedStyle {
         emit_if_changed!(self, default, buf, visibility, "visibility");
 
         // Note: language is stored but typically output via HTML lang attribute
+    }
+}
+
+/// CSS generic font families that must NOT be quoted.
+const GENERIC_FAMILIES: &[&str] = &[
+    "serif",
+    "sans-serif",
+    "monospace",
+    "cursive",
+    "fantasy",
+    "system-ui",
+    "ui-serif",
+    "ui-sans-serif",
+    "ui-monospace",
+    "ui-rounded",
+    "math",
+    "emoji",
+    "fangsong",
+];
+
+/// Quote font-family names that need quoting in CSS.
+///
+/// A comma-separated font stack like `din next lt pro,sans-serif` becomes
+/// `"din next lt pro",sans-serif` — generic families are left unquoted,
+/// custom names with spaces or leading digits are quoted.
+fn quote_font_family(buf: &mut String, family: &str) {
+    for (i, part) in family.split(',').enumerate() {
+        if i > 0 {
+            buf.push(',');
+        }
+        let trimmed = part.trim();
+        let is_generic = GENERIC_FAMILIES
+            .iter()
+            .any(|g| g.eq_ignore_ascii_case(trimmed));
+        let needs_quoting = !is_generic
+            && (trimmed.contains(' ')
+                || trimmed.starts_with(|c: char| c.is_ascii_digit())
+                || trimmed.contains('"')
+                || trimmed.is_empty());
+        if needs_quoting {
+            buf.push('"');
+            buf.push_str(trimmed);
+            buf.push('"');
+        } else {
+            buf.push_str(trimmed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn quoted(input: &str) -> String {
+        let mut buf = String::new();
+        quote_font_family(&mut buf, input);
+        buf
+    }
+
+    #[test]
+    fn test_font_family_quoting_spaces_and_digit_prefix() {
+        // Real-world case from B003ZK58TA: unquoted name with spaces + leading digit
+        assert_eq!(
+            quoted("001_cvi_cover-din next lt pro,sans-serif"),
+            r#""001_cvi_cover-din next lt pro",sans-serif"#
+        );
+    }
+
+    #[test]
+    fn test_font_family_quoting_spaces() {
+        assert_eq!(
+            quoted("DIN Next LT Pro,sans-serif"),
+            r#""DIN Next LT Pro",sans-serif"#
+        );
+    }
+
+    #[test]
+    fn test_font_family_no_quoting_single_word() {
+        assert_eq!(quoted("Helvetica"), "Helvetica");
+    }
+
+    #[test]
+    fn test_font_family_generic_not_quoted() {
+        assert_eq!(quoted("serif"), "serif");
+        assert_eq!(quoted("sans-serif"), "sans-serif");
+        assert_eq!(quoted("monospace"), "monospace");
+    }
+
+    #[test]
+    fn test_font_family_generic_case_insensitive() {
+        assert_eq!(quoted("Sans-Serif"), "Sans-Serif");
+    }
+
+    #[test]
+    fn test_font_family_full_stack() {
+        assert_eq!(
+            quoted("031_next-reads-shift light,palatino,palatino linotype,georgia,serif"),
+            r#""031_next-reads-shift light",palatino,"palatino linotype",georgia,serif"#
+        );
+    }
+
+    #[test]
+    fn test_font_family_leading_digit() {
+        assert_eq!(quoted("123font"), r#""123font""#);
+    }
+
+    #[test]
+    fn test_computed_style_font_family_quoted() {
+        let mut style = ComputedStyle::default();
+        style.font_family = Some("001_cvi_cover-din next lt pro,sans-serif".to_string());
+        let mut css = String::new();
+        style.to_css(&mut css);
+        assert!(
+            css.contains(r#"font-family: "001_cvi_cover-din next lt pro",sans-serif;"#),
+            "Expected quoted font-family in CSS output, got: {}",
+            css
+        );
     }
 }


### PR DESCRIPTION
Fixes #7

## Summary

Font-family names containing spaces or starting with a digit were written unquoted to CSS class rules. Per the CSS spec, unquoted identifiers starting with a digit are invalid — e-readers and browsers can't parse them and fall back to system fonts.

- Add `quote_font_family()` that properly quotes custom font names while leaving generic families (`serif`, `sans-serif`, `monospace`, etc.) unquoted
- Handles comma-separated font stacks correctly

**File changed:** `src/style/to_css.rs`

## Example

Real-world KFX book (B003ZK58TA) has font-family: `001_cvi_cover-din next lt pro,sans-serif`

Before (invalid CSS):
```css
font-family: 001_cvi_cover-din next lt pro,sans-serif;
```

After (valid CSS):
```css
font-family: "001_cvi_cover-din next lt pro",sans-serif;
```

## Spec references

- **CSS Fonts Module Level 4 §2.1.1** — [Family Name Syntax](https://www.w3.org/TR/css-fonts-4/#family-name-syntax): `<family-name> = <string> | <custom-ident>+`. The spec's own examples of invalid unquoted names include `Hawaii 5-0` (token starts with digit).
- **CSS Syntax Module Level 3 §4.2** — [Definitions](https://drafts.csswg.org/css-syntax-3/): ident-start code points are letters, non-ASCII code points, or `_`. Digits are valid *within* identifiers but cannot *start* them.
- **CSS Values Level 4 §4.2** — [Custom Identifiers](https://drafts.csswg.org/css-values-4/#custom-idents): a `<custom-ident>` must not start with a decimal digit.
- **Mathias Bynens** — [Unquoted font family names in CSS](https://mathiasbynens.be/notes/unquoted-font-family): comprehensive practical reference on when quoting is required.

## Prior art (non-GPL)

- **servo/rust-cssparser** (MPL-2.0) — [`serialize_identifier()`](https://github.com/servo/rust-cssparser) hex-escapes leading digits per CSS Syntax Module rules
- **LightningCSS** (MPL-2.0) — had a [critical bug](https://github.com/parcel-bundler/lightningcss/issues/120) from incorrectly stripping font-family quotes, breaking names like `"Goudy Bookletter 1911"` and `"Hawaii 5-0"`
- **Stylelint** (MIT) — [`font-family-name-quotes`](https://stylelint.io/user-guide/rules/font-family-name-quotes/) rule quotes names containing "white space, digits, or punctuation characters other than hyphens"

## Test plan

- [x] `test_font_family_quoting_spaces_and_digit_prefix` — real-world case with both issues
- [x] `test_font_family_quoting_spaces` — multi-word name
- [x] `test_font_family_no_quoting_single_word` — single-word left unquoted
- [x] `test_font_family_generic_not_quoted` — generic families never quoted
- [x] `test_font_family_generic_case_insensitive` — case-insensitive generic matching
- [x] `test_font_family_full_stack` — complex multi-font stack
- [x] `test_font_family_leading_digit` — digit prefix alone triggers quoting
- [x] `test_computed_style_font_family_quoted` — end-to-end through `ComputedStyle::to_css()`
- [x] Full test suite passes (496 existing + 8 new)