### PR TITLE
Only set the first title in metadata.title for EPUB parsing

### DIFF
--- a/src/epub/parser.rs
+++ b/src/epub/parser.rs
@@ -349,7 +349,9 @@ pub fn parse_opf(content: &str) -> io::Result<OpfData> {
                     let text = buf_text.clone();
                     match elem.as_str() {
                         "title" => {
-                            metadata.title = text;
+                            if metadata.title.is_empty() {
+                                metadata.title = text;
+                            }
                             if let Some(ref id) = current_element_id {
                                 element_ids.insert(id.clone(), MetaElement::Title);
                             }
@@ -1466,5 +1468,26 @@ mod tests {
             .find(|c| c.role == Some("edt".to_string()));
         assert!(editor.is_some());
         assert_eq!(editor.unwrap().name, "Editor Name");
+    }
+
+    #[test]
+    fn test_parse_opf_multiple_titles_uses_first() {
+        let opf = r##"<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title id="title1">The First Title</dc:title>
+    <dc:title id="title2">The Second Title</dc:title>
+    <dc:title id="title3">The Third Title</dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    <item id="ch1" href="ch1.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine><itemref idref="ch1"/></spine>
+</package>"##;
+
+        let result = parse_opf(opf).unwrap();
+        // Should only use the first title
+        assert_eq!(result.metadata.title, "The First Title");
     }
 }


### PR DESCRIPTION
Fixes zacharydenton/boko#14

## Overview
Fixed EPUB metadata parser to respect the W3C EPUB 3.3 specification by using only the first `<dc:title>` element as the primary title, instead of overwriting it with subsequent title elements (subtitles, etc.).

## Problem
The OPF parser was overwriting the `metadata.title` value each time it encountered a `<dc:title>` element. In EPUBs with multiple titles (main title, subtitle, etc.), this resulted in the last title element being used instead of the primary one.

### Example Issue
```xml
<dc:title id="maintitle">1929</dc:title>
<meta property="title-type" refines="#maintitle">main</meta>
<meta property="display-seq" refines="#maintitle">1</meta>
<dc:title id="subtitle">Inside the Greatest Crash in Wall Street History--and How It Shattered a Nation</dc:title>
<meta property="title-type" refines="#subtitle">subtitle</meta>
```

**Before**: `metadata.title` = "Inside the Greatest Crash in Wall Street History--and How It Shattered a Nation" (subtitle)
**After**: `metadata.title` = "1929" (primary title)

## Solution
Updated the title parsing logic in `src/epub/parser.rs` to only set `metadata.title` if it's empty (i.e., on the first occurrence). Subsequent `<dc:title>` elements are not added to that metadata value.

## Testing

Added new unit test to cover this case.