### PR TITLE
Recognize .azw extension as Mobi format

### DIFF
--- a/src/model/book.rs
+++ b/src/model/book.rs
@@ -201,7 +201,7 @@ impl Format {
             .and_then(|ext| match ext.to_lowercase().as_str() {
                 "epub" => Some(Format::Epub),
                 "azw3" => Some(Format::Azw3),
-                "mobi" => Some(Format::Mobi),
+                "mobi" | "azw" => Some(Format::Mobi),
                 "kfx" => Some(Format::Kfx),
                 "md" | "txt" => Some(Format::Markdown),
                 _ => None,
@@ -563,5 +563,23 @@ impl TocEntry {
             play_order: None,
             target: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_path_recognises_known_extensions() {
+        assert_eq!(Format::from_path("book.epub"), Some(Format::Epub));
+        assert_eq!(Format::from_path("book.azw3"), Some(Format::Azw3));
+        assert_eq!(Format::from_path("book.mobi"), Some(Format::Mobi));
+        assert_eq!(Format::from_path("book.azw"), Some(Format::Mobi));
+        assert_eq!(Format::from_path("book.kfx"), Some(Format::Kfx));
+        assert_eq!(Format::from_path("notes.md"), Some(Format::Markdown));
+        assert_eq!(Format::from_path("book.AZW"), Some(Format::Mobi));
+        assert_eq!(Format::from_path("book.unknown"), None);
+        assert_eq!(Format::from_path("no_extension"), None);
     }
 }


### PR DESCRIPTION
Pretty small one - Amazon's pre-Kindle-Store .azw files use the same Mobipocket-based format as .mobi files (PalmDB container + PalmDOC/HuffCDIC compressed HTML, EXTH metadata, optional NCX). The two extensions are interchangeable for the importer — only the file extension differs. Still quite a few .azw books out there.

Add .azw to the from_path() extension match so callers that hand boko an .azw path don't have to special-case detection, and so the format auto-detection in Book::open() works.

Add a unit test covering all recognised extensions plus uppercase and unknown cases.  