### PR TITLE
azw3: resolve kindle:embed refs inside served CSS flows

### DIFF
--- a/src/import/azw3.rs
+++ b/src/import/azw3.rs
@@ -22,6 +22,7 @@ use crate::mobi::{
     is_metadata_record, palmdoc, parse_exth, parse_fdst, strip_trailing_data, transform,
 };
 use crate::model::{AnchorTarget, Chapter, GlobalNodeId, Landmark, Metadata, TocEntry};
+use memchr::memmem;
 
 /// AZW3/KF8 format importer with lazy loading.
 pub struct Azw3Importer {
@@ -176,7 +177,13 @@ impl Importer for Azw3Importer {
                 }
             })?;
             let text = self.cached_text()?;
-            return Ok(flow_slice(text, start, end).to_vec());
+            // The CSS itself may reference embedded resources (`@font-face`
+            // src, background images) as `kindle:embed:XXXX[?mime=...]`;
+            // rewrite those to the discovered asset paths so they resolve.
+            return Ok(rewrite_css_embed_refs(
+                flow_slice(text, start, end),
+                &self.assets,
+            ));
         }
 
         // Parse index from path (images/image_XXXX.ext or fonts/font_XXXX.ext).
@@ -793,6 +800,63 @@ fn flow_slice(text: &[u8], start: usize, end: usize) -> &[u8] {
     if start <= end { &text[start..end] } else { &[] }
 }
 
+/// Rewrite `kindle:embed:XXXX[?mime=...]` references inside CSS to the
+/// discovered asset path for that embed index.
+///
+/// The KF8 writer stores CSS-referenced resources (`@font-face` src,
+/// background images) as `url(kindle:embed:XXXX)` where XXXX is the base32
+/// resource index + 1 — the same numbering `transform_kindle_refs` handles in
+/// chapter HTML. The discovered assets list already names each record
+/// `images/image_NNNN.ext` or `fonts/font_NNNN.ext`, so the index picks the
+/// right path (and extension) directly; anything unresolvable is left as a
+/// best-guess image path rather than a dangling `kindle:` URL.
+fn rewrite_css_embed_refs(css: &[u8], assets: &[String]) -> Vec<u8> {
+    let needle = b"kindle:embed:";
+    let finder = memmem::Finder::new(needle);
+
+    let mut output = Vec::with_capacity(css.len());
+    let mut pos = 0;
+
+    while let Some(rel_start) = finder.find(&css[pos..]) {
+        let start = pos + rel_start;
+        output.extend_from_slice(&css[pos..start]);
+
+        let after = &css[start + needle.len()..];
+        // The reference ends at ) " ' or ? (a ?mime=... suffix).
+        let end_pos = after
+            .iter()
+            .position(|&b| b == b')' || b == b'"' || b == b'\'' || b == b'?')
+            .unwrap_or(after.len());
+        let embed_num = transform::parse_base32(&after[..end_pos]);
+        let embed_idx = embed_num.saturating_sub(1);
+
+        // Skip a ?mime=... suffix if present.
+        let skip = if end_pos < after.len() && after[end_pos] == b'?' {
+            after[end_pos..]
+                .iter()
+                .position(|&b| b == b')' || b == b'"' || b == b'\'')
+                .map(|p| end_pos + p)
+                .unwrap_or(after.len())
+        } else {
+            end_pos
+        };
+
+        let image_prefix = format!("images/image_{embed_idx:04}.");
+        let font_prefix = format!("fonts/font_{embed_idx:04}.");
+        let asset_path = assets
+            .iter()
+            .find(|s| s.starts_with(&image_prefix) || s.starts_with(&font_prefix))
+            .cloned()
+            .unwrap_or_else(|| format!("images/image_{embed_idx:04}.jpg"));
+
+        output.extend_from_slice(asset_path.as_bytes());
+        pos = start + needle.len() + skip;
+    }
+
+    output.extend_from_slice(&css[pos..]);
+    output
+}
+
 /// Build chapter parts by combining skeletons with div content.
 fn build_parts(
     text: &[u8],
@@ -867,4 +931,64 @@ fn toc_node_to_entry(node: TocNode) -> TocEntry {
     entry.play_order = Some(node.ncx_index);
     entry.children = node.children.into_iter().map(toc_node_to_entry).collect();
     entry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rewrite_css_embed_refs;
+
+    fn assets() -> Vec<String> {
+        vec![
+            "images/image_0000.png".to_string(),
+            "fonts/font_0001.otf".to_string(),
+            "images/image_0002.gif".to_string(),
+        ]
+    }
+
+    #[test]
+    fn rewrites_font_ref_with_mime_suffix() {
+        let css = b"@font-face { src: url(kindle:embed:0002?mime=font/otf); }";
+        let out = rewrite_css_embed_refs(css, &assets());
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "@font-face { src: url(fonts/font_0001.otf); }"
+        );
+    }
+
+    #[test]
+    fn rewrites_bare_image_ref_using_discovered_extension() {
+        let css = b"h1 { background: url(kindle:embed:0001); }";
+        let out = rewrite_css_embed_refs(css, &assets());
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "h1 { background: url(images/image_0000.png); }"
+        );
+    }
+
+    #[test]
+    fn unresolvable_ref_falls_back_to_image_path() {
+        let css = b"p { background: url(kindle:embed:000A); }";
+        let out = rewrite_css_embed_refs(css, &assets());
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "p { background: url(images/image_0009.jpg); }"
+        );
+    }
+
+    #[test]
+    fn css_without_embed_refs_is_unchanged() {
+        let css = b"p { margin: 1em; } /* kindle:flow stays */";
+        let out = rewrite_css_embed_refs(css, &assets());
+        assert_eq!(out, css);
+    }
+
+    #[test]
+    fn quoted_ref_terminates_at_quote() {
+        let css = b"p { background: url('kindle:embed:0003'); }";
+        let out = rewrite_css_embed_refs(css, &assets());
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "p { background: url('images/image_0002.gif'); }"
+        );
+    }
 }

--- a/tests/azw3_roundtrip.rs
+++ b/tests/azw3_roundtrip.rs
@@ -10,6 +10,8 @@
 //! Each assertion below corresponds to a specific bug class previously fixed
 //! in the writer; if one regresses it should fail here, not on a Kindle.
 
+mod common;
+
 use std::io::Cursor;
 
 use boko::model::{Format, TocEntry};
@@ -234,4 +236,64 @@ fn azw3_roundtrip_preserves_stylesheet_styles() {
         "authored small-caps styling must survive the AZW3 roundtrip \
          (KF8 flow CSS regression)"
     );
+}
+
+/// CSS-referenced resources must survive the round trip. The writer rewrites
+/// `url(...)` values inside stylesheets to `url(kindle:embed:XXXX)`; on
+/// import those references must come back as discovered asset paths — a
+/// stylesheet that still says `kindle:embed:` references a resource no EPUB
+/// consumer can resolve (broken @font-face fonts and background images).
+#[test]
+fn azw3_roundtrip_resolves_embed_refs_inside_css() {
+    let epub = common::EpubBuilder::new("CSS Embed Refs")
+        .css("h1 { background-image: url(../images/pic.png); }")
+        .image("images/pic.png", common::tiny_png())
+        .doc(common::Doc::new(
+            "text/ch1.xhtml",
+            "Chapter 1",
+            "<h1>Heading</h1><p>Body text for the embed-ref roundtrip.</p>",
+        ))
+        .nav(vec![common::Nav::new("Chapter 1", "text/ch1.xhtml")])
+        .build();
+
+    let book = Book::from_bytes(&epub, Format::Epub).expect("open synthetic epub");
+    let mut buf = Cursor::new(Vec::new());
+    boko::export::Azw3Exporter::new()
+        .export(&book, &mut buf)
+        .expect("azw3 export");
+    let azw3 = buf.into_inner();
+
+    let book = Book::from_bytes(&azw3, Format::Azw3).expect("reopen azw3");
+    let css_asset = book
+        .list_assets()
+        .iter()
+        .find(|a| a.starts_with("styles/") && a.ends_with(".css"))
+        .cloned()
+        .expect("CSS flow asset discovered");
+
+    let css = book.load_asset(&css_asset).expect("load CSS flow");
+    let css_text = String::from_utf8_lossy(&css);
+    assert!(
+        !css_text.contains("kindle:embed:"),
+        "kindle:embed refs must be rewritten to asset paths, got: {css_text}"
+    );
+
+    // Non-vacuous: the writer rewrote url(../images/pic.png) to a
+    // kindle:embed ref (the source path cannot survive), so the only way the
+    // imported CSS references a discovered `images/image_NNNN` asset is the
+    // import-side rewrite doing its job.
+    let referenced = book
+        .list_assets()
+        .iter()
+        .find(|a| css_text.contains(a.as_str()))
+        .cloned()
+        .expect("CSS must reference a discovered asset path");
+    assert!(
+        referenced.starts_with("images/image_"),
+        "expected a discovered image asset, got {referenced}"
+    );
+    let bytes = book
+        .load_asset(&referenced)
+        .expect("referenced asset loads");
+    assert!(!bytes.is_empty(), "referenced asset must have content");
 }


### PR DESCRIPTION
Fixes #26.

## Problem

*Reworked for 0.5.0: the original version of this PR added CSS-flow discovery and serving, which `b21f08e` has since implemented upstream — thanks! This PR is now just the remaining half.*

KF8 stylesheet flows are served from the FDST flow table as of 0.5.0, but they are served **raw**. The CSS content itself can reference embedded resources — the KF8 writer (both Amazon's tooling and boko's own `rewrite_css_references_fast`) stores CSS-referenced resources as `url(kindle:embed:XXXX[?mime=...])`, the same base32 numbering used for `kindle:embed` in chapter HTML (see the [MobileRead KF8 documentation](https://wiki.mobileread.com/wiki/KF8)). Chapter HTML gets those references rewritten by `transform_kindle_refs`, but CSS does not: `@font-face` `src` and `background-image` URLs come back as `kindle:` URLs no EPUB consumer can resolve — embedded fonts and CSS-referenced images silently break, and the output fails [EPUB 3.3](https://www.w3.org/TR/epub-33/) resource checks.

## Fix

`rewrite_css_embed_refs` in `src/import/azw3.rs`, applied in `load_asset`'s styles branch: each embed index maps to the discovered asset path — `images/image_NNNN.ext` vs `fonts/font_NNNN.ext` picks the right prefix *and* extension straight from discovery — with a best-guess image path as fallback for unresolvable indices (matching `transform_kindle_refs`' behaviour in HTML).

## Tests

- 5 unit tests: font ref with `?mime=` suffix, bare image ref, quoted ref, unresolvable-index fallback, and no-op on embed-free CSS
- `azw3_roundtrip_resolves_embed_refs_inside_css`: a synthetic EPUB (via the existing `common::EpubBuilder`) whose CSS references an image goes EPUB→AZW3→import; the reference must come back pointing at a discovered, loadable asset. Fails on current master with `url(kindle:embed:0001)` served verbatim.

`cargo fmt --check`, `cargo clippy --lib`, `cargo test` all pass.